### PR TITLE
Add JSON schema for book metadata

### DIFF
--- a/lavender-book.json
+++ b/lavender-book.json
@@ -1,40 +1,61 @@
 {
-    "$schema":     "http://json-schema.org/draft-06/schema#",
-    "definitions": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title":   "Lavender Book",
+    "$defs":   {
         "book":   {
             "type":       "object",
             "properties": {
                 "texture":                            {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Texture",
+                    "description": "This is used to decide which texture to use for the GUI of your book. There are some built into Lavender following the lavender:textures/gui/<color>_book.png template",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "extend":                             {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Extend",
+                    "description": "Should you be adding content to another mod with a Lavender guidebook, you can set this property to extend the original mod's book with your own entries and categories. To read more on how this works, look at the respective article",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "dynamic_book_model":                 {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Dynamic Book Model",
+                    "description": "Lavender has a built-in book, the dynamic book, which uses NBT data to emulate any book currently loaded into the game. This is primarily of interest if you are a modpack developer and thus cannot register your own book item through Lavender's API. You can set this property to another item model's ID (e.g. mymodpack:my_book_model -> assets/mymodpack/models/item/my_book_model.json) to make the dynamic book use said model when it is emulating your book",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "dynamic_book_name":                  {
-                    "$ref": "lavender-common.json#/definitions/text"
+                    "title":       "Dynamic Book Name",
+                    "description": "The name the dynamic book should display when it is set to emulate your book. This property expects a Minecraft text object (which can also be just a plain string)",
+                    "$ref":        "lavender-common.json#/$defs/text"
                 },
                 "open_sound":                         {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Open Sound",
+                    "description": "The sound played when the book is opened",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "flipping_sound":                     {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Flipping Sound",
+                    "description": "The sound played when the page is flipped",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "intro_entry":                        {
-                    "$ref": "lavender-common.json#/definitions/identifier"
+                    "title":       "Intro Entry",
+                    "description": "The introduction entry shown when the book is first opened",
+                    "$ref":        "lavender-common.json#/$defs/identifier"
                 },
                 "display_completion":                 {
-                    "type":    "boolean",
-                    "default": false
+                    "title":       "Display Completion",
+                    "description": "If some or all entries of your book are locked behind advancements, you can set this to true to make the book display a completion bar on the main index page and separately for each category",
+                    "type":        "boolean",
+                    "default":     false
                 },
                 "display_unread_entry_notifications": {
-                    "type":    "boolean",
-                    "default": true
+                    "title":       "Display Unread Entry Notifications",
+                    "description": "If unread entry notifications should be shown",
+                    "type":        "boolean",
+                    "default":     true
                 },
                 "macros":                             {
-                    "$ref": "#/definitions/macros"
+                    "title":       "Macros",
+                    "description": "The macros to be applied when processing the page contents",
+                    "$ref":        "#/$defs/macros"
                 }
             }
         },
@@ -43,6 +64,5 @@
             "additionalProperties": true
         }
     },
-    "title":       "Lavender Book",
-    "$ref":        "#/definitions/book"
+    "$ref":    "#/$defs/book"
 }

--- a/lavender-book.json
+++ b/lavender-book.json
@@ -1,0 +1,48 @@
+{
+    "$schema":     "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "book":   {
+            "type":       "object",
+            "properties": {
+                "texture":                            {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "extend":                             {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "dynamic_book_model":                 {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "dynamic_book_name":                  {
+                    "$ref": "lavender-common.json#/definitions/text"
+                },
+                "open_sound":                         {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "flipping_sound":                     {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "intro_entry":                        {
+                    "$ref": "lavender-common.json#/definitions/identifier"
+                },
+                "display_completion":                 {
+                    "type":    "boolean",
+                    "default": false
+                },
+                "display_unread_entry_notifications": {
+                    "type":    "boolean",
+                    "default": true
+                },
+                "macros":                             {
+                    "$ref": "#/definitions/macros"
+                }
+            }
+        },
+        "macros": {
+            "type":                 "object",
+            "additionalProperties": true
+        }
+    },
+    "title":       "Lavender Book",
+    "$ref":        "#/definitions/book"
+}

--- a/lavender-category.json
+++ b/lavender-category.json
@@ -1,23 +1,24 @@
 {
-    "$schema":     "http://json-schema.org/draft-06/schema#",
-    "definitions": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title":   "Lavender Category",
+    "$defs":   {
         "category": {
             "type":       "object",
             "properties": {
                 "parent":  {
                     "title":       "Parent",
                     "description": "The parent of this category",
-                    "$ref":        "lavender-common.json#/definitions/identifier_or_partial"
+                    "$ref":        "lavender-common.json#/$defs/identifier_or_partial"
                 },
                 "title":   {
                     "title":       "Title",
                     "description": "The title of this category, to be displayed at the top of its landing page",
-                    "$ref":        "lavender-common.json#/definitions/text"
+                    "$ref":        "lavender-common.json#/$defs/text"
                 },
                 "icon":    {
                     "title":       "Icon",
                     "description": "An item to use as this category's icon in the index (optionally including NBT)",
-                    "$ref":        "lavender-common.json#/definitions/itemstack"
+                    "$ref":        "lavender-common.json#/$defs/itemstack"
                 },
                 "secret":  {
                     "title":       "Secret",
@@ -36,6 +37,5 @@
             ]
         }
     },
-    "title":       "Lavender Category",
-    "$ref":        "#/definitions/category"
+    "$ref":    "#/$defs/category"
 }

--- a/lavender-category.json
+++ b/lavender-category.json
@@ -1,0 +1,41 @@
+{
+    "$schema":     "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "category": {
+            "type":       "object",
+            "properties": {
+                "parent":  {
+                    "title":       "Parent",
+                    "description": "The parent of this category",
+                    "$ref":        "lavender-common.json#/definitions/identifier_or_partial"
+                },
+                "title":   {
+                    "title":       "Title",
+                    "description": "The title of this category, to be displayed at the top of its landing page",
+                    "$ref":        "lavender-common.json#/definitions/text"
+                },
+                "icon":    {
+                    "title":       "Icon",
+                    "description": "An item to use as this category's icon in the index (optionally including NBT)",
+                    "$ref":        "lavender-common.json#/definitions/itemstack"
+                },
+                "secret":  {
+                    "title":       "Secret",
+                    "description": "If all entries in this category are currently locked or invisible to the player, don't show it all instead of simply displaying it as locked",
+                    "type":        "boolean",
+                    "default":     false
+                },
+                "ordinal": {
+                    "title":       "Ordinal",
+                    "description": "A sorting index for this category, displayed in ascending order. Categories with no ordinal are displayed last",
+                    "type":        "number"
+                }
+            },
+            "required":   [
+                "title"
+            ]
+        }
+    },
+    "title":       "Lavender Category",
+    "$ref":        "#/definitions/category"
+}

--- a/lavender-common.json
+++ b/lavender-common.json
@@ -1,0 +1,37 @@
+{
+    "$schema":     "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "partial_identifier":    {
+            "type":    "string",
+            "pattern": "^[a-z0-9/._-]+$"
+        },
+        "identifier":            {
+            "type":    "string",
+            "pattern": "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+$"
+        },
+        "identifier_or_partial": {
+            "anyOf": [
+                { "$ref": "#/definitions/partial_identifier" },
+                { "$ref": "#/definitions/identifier" }
+            ]
+        },
+        "text":                  {
+            "type": "string"
+        },
+        "tag":                   {
+            "type":    "string",
+            "pattern": "^#([a-z0-9_\\.-]+:)?[a-z0-9/\\._-]+$"
+        },
+        "itemstack":             {
+            "type":    "string",
+            "pattern": "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+(\\{.*\\})?$"
+        },
+        "itemstacks":            {
+            "anyOf": [
+                { "$ref": "#/definitions/itemstack" },
+                { "$ref": "#/definitions/tag" }
+            ]
+        }
+    },
+    "title":       "Lavender Common Definitions"
+}

--- a/lavender-common.json
+++ b/lavender-common.json
@@ -1,37 +1,51 @@
 {
-    "$schema":     "http://json-schema.org/draft-06/schema#",
-    "definitions": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title":   "Lavender Common Definitions",
+    "$defs":   {
         "partial_identifier":    {
-            "type":    "string",
-            "pattern": "^[a-z0-9/._-]+$"
+            "title":       "Partial Identifier",
+            "description": "A partial identifier",
+            "type":        "string",
+            "pattern":     "^[a-z0-9/._-]+$"
         },
         "identifier":            {
-            "type":    "string",
-            "pattern": "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+$"
+            "title":       "Identifier",
+            "description": "An identifier",
+            "type":        "string",
+            "pattern":     "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+$"
         },
         "identifier_or_partial": {
-            "anyOf": [
-                { "$ref": "#/definitions/partial_identifier" },
-                { "$ref": "#/definitions/identifier" }
+            "title":       "Identifier or Partial Identifier",
+            "description": "Either an identifier or a partial identifier",
+            "anyOf":       [
+                { "$ref": "#/$defs/partial_identifier" },
+                { "$ref": "#/$defs/identifier" }
             ]
         },
         "text":                  {
-            "type": "string"
+            "title":       "Text",
+            "description": "A Minecraft text object",
+            "type":        "string"
         },
         "tag":                   {
-            "type":    "string",
-            "pattern": "^#([a-z0-9_\\.-]+:)?[a-z0-9/\\._-]+$"
+            "title":       "Tag",
+            "description": "A Minecraft tag",
+            "type":        "string",
+            "pattern":     "^#([a-z0-9_\\.-]+:)?[a-z0-9/\\._-]+$"
         },
         "itemstack":             {
-            "type":    "string",
-            "pattern": "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+(\\{.*\\})?$"
+            "title":       "Item Stack",
+            "description": "A Minecraft item stack with optional nbt",
+            "type":        "string",
+            "pattern":     "^[a-z0-9_\\.-]+:[a-z0-9/\\._-]+(\\{.*\\})?$"
         },
         "itemstacks":            {
-            "anyOf": [
-                { "$ref": "#/definitions/itemstack" },
-                { "$ref": "#/definitions/tag" }
+            "title":       "Item Stacks",
+            "description": "Either a Minecraft item stack or a Minecraft tag",
+            "anyOf":       [
+                { "$ref": "#/$defs/itemstack" },
+                { "$ref": "#/$defs/tag" }
             ]
         }
-    },
-    "title":       "Lavender Common Definitions"
+    }
 }

--- a/lavender-common.json
+++ b/lavender-common.json
@@ -6,7 +6,7 @@
             "title":       "Partial Identifier",
             "description": "A partial identifier",
             "type":        "string",
-            "pattern":     "^[a-z0-9/._-]+$"
+            "pattern":     "^[a-z0-9/\\._-]+$"
         },
         "identifier":            {
             "title":       "Identifier",

--- a/lavender-entry.json
+++ b/lavender-entry.json
@@ -1,0 +1,56 @@
+{
+    "$schema":     "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "entry": {
+            "properties": {
+                "category":              {
+                    "title":       "Category",
+                    "description": "The category this entry belongs to",
+                    "$ref":        "lavender-common.json#/definitions/identifier_or_partial"
+                },
+                "title":                 {
+                    "title":       "Title",
+                    "description": "The title of this entry, to be displayed in the entry index and at top of the first page",
+                    "$ref":        "lavender-common.json#/definitions/text"
+                },
+                "icon":                  {
+                    "title":       "Icon",
+                    "description": "An item to use as this entry's icon in the index (optionally including NBT)",
+                    "$ref":        "lavender-common.json#/definitions/itemstack"
+                },
+                "secret":                {
+                    "title":       "Secret",
+                    "description": "If this entry is locked due to a missing advancement, don't show it to the player at all instead of simply displaying it as locked",
+                    "type":        "boolean",
+                    "default":     false
+                },
+                "ordinal":               {
+                    "title":       "Ordinal",
+                    "description": "A sorting index for this entry, displayed in ascending order. Entries with no ordinal are displayed last",
+                    "type":        "number"
+                },
+                "associated_items":      {
+                    "title":       "Associated Items",
+                    "description": "A list of item (with optional NBT) which should link to this entry in their tooltip and, if the respective item is a block item, when looking at said block while holding the book",
+                    "type":        "array",
+                    "items":       {
+                        "$ref": "lavender-common.json#/definitions/itemstacks"
+                    },
+                    "default":     [ ]
+                },
+                "required_advancements": {
+                    "title":       "Required Advancements",
+                    "description": "A list of advancement IDs which the player must have completed before they can view this entry. If display_completion is true in the book definition, a progress bar will indicate to the player how many entries they have unlocked/left to go",
+                    "type":        "array",
+                    "items":       {
+                        "$ref": "lavender-common.json#/definitions/identifier"
+                    },
+                    "default":     [ ]
+                }
+            },
+            "required":   [ "title" ]
+        }
+    },
+    "title":       "Lavender Entry",
+    "$ref":        "#/definitions/entry"
+}

--- a/lavender-entry.json
+++ b/lavender-entry.json
@@ -1,22 +1,23 @@
 {
-    "$schema":     "http://json-schema.org/draft-06/schema#",
-    "definitions": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title":   "Lavender Entry",
+    "$defs":   {
         "entry": {
             "properties": {
                 "category":              {
                     "title":       "Category",
                     "description": "The category this entry belongs to",
-                    "$ref":        "lavender-common.json#/definitions/identifier_or_partial"
+                    "$ref":        "lavender-common.json#/$defs/identifier_or_partial"
                 },
                 "title":                 {
                     "title":       "Title",
                     "description": "The title of this entry, to be displayed in the entry index and at top of the first page",
-                    "$ref":        "lavender-common.json#/definitions/text"
+                    "$ref":        "lavender-common.json#/$defs/text"
                 },
                 "icon":                  {
                     "title":       "Icon",
                     "description": "An item to use as this entry's icon in the index (optionally including NBT)",
-                    "$ref":        "lavender-common.json#/definitions/itemstack"
+                    "$ref":        "lavender-common.json#/$defs/itemstack"
                 },
                 "secret":                {
                     "title":       "Secret",
@@ -34,7 +35,7 @@
                     "description": "A list of item (with optional NBT) which should link to this entry in their tooltip and, if the respective item is a block item, when looking at said block while holding the book",
                     "type":        "array",
                     "items":       {
-                        "$ref": "lavender-common.json#/definitions/itemstacks"
+                        "$ref": "lavender-common.json#/$defs/itemstacks"
                     },
                     "default":     [ ]
                 },
@@ -43,14 +44,15 @@
                     "description": "A list of advancement IDs which the player must have completed before they can view this entry. If display_completion is true in the book definition, a progress bar will indicate to the player how many entries they have unlocked/left to go",
                     "type":        "array",
                     "items":       {
-                        "$ref": "lavender-common.json#/definitions/identifier"
+                        "$ref": "lavender-common.json#/$defs/identifier"
                     },
                     "default":     [ ]
                 }
             },
-            "required":   [ "title" ]
+            "required":   [
+                "title"
+            ]
         }
     },
-    "title":       "Lavender Entry",
-    "$ref":        "#/definitions/entry"
+    "$ref":    "#/$defs/entry"
 }


### PR DESCRIPTION
I was unsure where to put these, so I slapped them in the root directory.

I chose the root directory for consistency, as `owo-ui.xsd` is in the root directory for owo-lib.
If you would like me to place them elsewhere, just let me know and I can do that.

Also, I did not include `icon_sprite` in the schema, as even though the docs mention it, after looking at the code, it is not a valid property and will just be ignored.

The docs should also be appropriately updated to tell users to include
```json
"$schema": "https://raw.githubusercontent.com/wisp-forest/lavender/1.20.3/lavender-book.json"
```
at the top of their book's json file,
```json
"$schema": "https://raw.githubusercontent.com/wisp-forest/lavender/1.20.3/lavender-category.json"
```
in the json metadata for their categories, and
```json
"$schema": "https://raw.githubusercontent.com/wisp-forest/lavender/1.20.3/lavender-entry.json"
```
in the json metadata for their entries.