### PR TITLE
Various changes to StructureTemplates, 1.20.2 branch.

### DIFF
--- a/src/main/java/io/wispforest/lavender/book/LavenderClientStorage.java
+++ b/src/main/java/io/wispforest/lavender/book/LavenderClientStorage.java
@@ -6,14 +6,23 @@ import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import io.wispforest.lavender.Lavender;
 import io.wispforest.lavender.client.LavenderClient;
+import io.wispforest.lavender.client.StructureOverlayRenderer;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class LavenderClientStorage {
 
@@ -23,6 +32,9 @@ public class LavenderClientStorage {
     private static final TypeToken<Map<UUID, Set<Identifier>>> OPENED_BOOKS_TYPE = new TypeToken<>() {};
     private static Map<UUID, Set<Identifier>> openedBooks;
 
+    private static final TypeToken<Map<UUID, List<ActiveStructureOverlay>>> ACTIVE_STRUCTURES_TYPE = new TypeToken<>() {};
+    private static Map<UUID, List<ActiveStructureOverlay>> activeStructures;
+
     private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Identifier.class, new Identifier.Serializer()).setPrettyPrinting().create();
 
     static {
@@ -31,9 +43,11 @@ public class LavenderClientStorage {
 
             bookmarks = GSON.fromJson(data.get("bookmarks"), BOOKMARKS_TYPE);
             openedBooks = GSON.fromJson(data.get("opened_books"), OPENED_BOOKS_TYPE);
+            activeStructures = GSON.fromJson(data.get("active_structures"), ACTIVE_STRUCTURES_TYPE);
         } catch (Exception e) {
             bookmarks = new HashMap<>();
             openedBooks = new HashMap<>();
+            activeStructures = new HashMap<>();
             save();
         }
     }
@@ -78,11 +92,29 @@ public class LavenderClientStorage {
         return openedBooks.computeIfAbsent(LavenderClient.currentWorldId(), $ -> new HashSet<>());
     }
 
+    public static List<ActiveStructureOverlay> getActiveStructures() {
+        return activeStructures.computeIfAbsent(LavenderClient.currentWorldId(), $ -> new ArrayList<>());
+    }
+
+    public static void setActiveStructures(Map<BlockPos, StructureOverlayRenderer.OverlayEntry> activeStructures) {
+        getActiveStructures().clear();
+        getActiveStructures().addAll(activeStructures.entrySet()
+                .stream()
+                .map((entry) -> {
+                    var pos = entry.getKey();
+                    var overlay = entry.getValue();
+                    return new ActiveStructureOverlay(pos, overlay.structureId, overlay.rotation, overlay.visibleLayer);
+                })
+                .toList());
+        save();
+    }
+
     private static void save() {
         try {
             var data = new JsonObject();
             data.add("bookmarks", GSON.toJsonTree(bookmarks, BOOKMARKS_TYPE.getType()));
             data.add("opened_books", GSON.toJsonTree(openedBooks, OPENED_BOOKS_TYPE.getType()));
+            data.add("active_structure", GSON.toJsonTree(activeStructures, ACTIVE_STRUCTURES_TYPE.getType()));
 
             Files.writeString(storageFile(), GSON.toJson(data));
         } catch (IOException e) {
@@ -106,4 +138,9 @@ public class LavenderClientStorage {
             };
         }
     }
+
+    public record ActiveStructureOverlay(BlockPos pos, Identifier id, BlockRotation rotation, int visibleLayer) {
+
+    }
 }
+

--- a/src/main/java/io/wispforest/lavender/book/StructureComponent.java
+++ b/src/main/java/io/wispforest/lavender/book/StructureComponent.java
@@ -36,7 +36,7 @@ public class StructureComponent extends BaseComponent {
         var entityBuffers = client.getBufferBuilders().getEntityVertexConsumers();
 
         float scale = Math.min(this.width, this.height);
-        scale /= Math.max(structure.xSize, Math.max(structure.ySize, structure.zSize));
+        scale /= Math.max(this.structure.xSize(), Math.max(this.structure.ySize(), this.structure.zSize()));
         scale /= 1.625f;
 
         var matrices = context.getMatrices();
@@ -47,7 +47,7 @@ public class StructureComponent extends BaseComponent {
 
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(this.displayAngle));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees((float) (System.currentTimeMillis() / 75d % 360d)));
-        matrices.translate(this.structure.xSize / -2f, this.structure.ySize / -2f, this.structure.zSize / -2f);
+        matrices.translate(this.structure.xSize() / -2.0f, this.structure.ySize() / -2.0f, this.structure.zSize() / -2.0f);
 
         structure.forEachPredicate((blockPos, predicate) -> {
             if (this.visibleLayer != -1 && this.visibleLayer != blockPos.getY()) return;
@@ -70,7 +70,7 @@ public class StructureComponent extends BaseComponent {
         entityBuffers.draw();
         DiffuseLighting.enableGuiDepthLighting();
 
-        if (StructureOverlayRenderer.isShowingOverlay(this.structure.id)) {
+        if (StructureOverlayRenderer.isShowingOverlay(this.structure.id())) {
             context.drawText(client.textRenderer, Text.translatable("text.lavender.structure_component.active_overlay_hint"), this.x + this.width - 5 - client.textRenderer.getWidth("⚓"), this.y + this.height - 9 - 5, 0, false);
             this.tooltip(Text.translatable("text.lavender.structure_component.hide_hint"));
         } else {
@@ -83,11 +83,11 @@ public class StructureComponent extends BaseComponent {
         var result = super.onMouseDown(mouseX, mouseY, button);
         if (button != GLFW.GLFW_MOUSE_BUTTON_LEFT) return result;
 
-        if (StructureOverlayRenderer.isShowingOverlay(this.structure.id)) {
-            StructureOverlayRenderer.removeAllOverlays(this.structure.id);
+        if (StructureOverlayRenderer.isShowingOverlay(this.structure.id())) {
+            StructureOverlayRenderer.removeAllOverlays(this.structure.id());
         } else {
-            StructureOverlayRenderer.addPendingOverlay(this.structure.id);
-            StructureOverlayRenderer.restrictVisibleLayer(this.structure.id, this.visibleLayer);
+            StructureOverlayRenderer.addPendingOverlay(this.structure.id());
+            StructureOverlayRenderer.restrictVisibleLayer(this.structure.id(), this.visibleLayer);
 
             MinecraftClient.getInstance().setScreen(null);
         }
@@ -96,7 +96,7 @@ public class StructureComponent extends BaseComponent {
     }
 
     public StructureComponent visibleLayer(int visibleLayer) {
-        StructureOverlayRenderer.restrictVisibleLayer(this.structure.id, visibleLayer);
+        StructureOverlayRenderer.restrictVisibleLayer(this.structure.id(), visibleLayer);
 
         this.visibleLayer = visibleLayer;
         return this;

--- a/src/main/java/io/wispforest/lavender/client/LavenderClient.java
+++ b/src/main/java/io/wispforest/lavender/client/LavenderClient.java
@@ -113,6 +113,7 @@ public class LavenderClient implements ClientModInitializer {
 
         ClientPlayNetworking.registerGlobalReceiver(Lavender.WORLD_ID_CHANNEL, (client, handler, buf, responseSender) -> {
             currentWorldId = buf.readUuid();
+            StructureOverlayRenderer.reloadActiveOverlays();
         });
     }
 

--- a/src/main/java/io/wispforest/lavender/client/StructureOverlayRenderer.java
+++ b/src/main/java/io/wispforest/lavender/client/StructureOverlayRenderer.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL30C;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -58,6 +59,10 @@ public class StructureOverlayRenderer {
 
     private static final Identifier HUD_COMPONENT_ID = Lavender.id("structure_overlay");
     private static final Identifier BARS_TEXTURE = Lavender.id("textures/gui/structure_overlay_bars.png");
+
+    public static Map<BlockPos, OverlayEntry> getActiveOverlays() {
+        return Collections.unmodifiableMap(ACTIVE_OVERLAYS);
+    }
 
     public static void addPendingOverlay(Identifier structure) {
         PENDING_OVERLAY = new OverlayEntry(structure, BlockRotation.NONE);
@@ -302,7 +307,7 @@ public class StructureOverlayRenderer {
         matrices.pop();
     }
 
-    private static class OverlayEntry {
+    public static class OverlayEntry {
 
         public final Identifier structureId;
 

--- a/src/main/java/io/wispforest/lavender/client/StructureOverlayRenderer.java
+++ b/src/main/java/io/wispforest/lavender/client/StructureOverlayRenderer.java
@@ -278,8 +278,8 @@ public class StructureOverlayRenderer {
         return switch (PENDING_OVERLAY.rotation) {
             case NONE -> new Vec3i(-structure.anchor().getX(), -structure.anchor().getY(), -structure.anchor().getZ());
             case CLOCKWISE_90 -> new Vec3i(-structure.anchor().getZ(), -structure.anchor().getY(), -structure.anchor().getX());
-            case CLOCKWISE_180 -> new Vec3i(-structure.xSize + structure.anchor.getX() + 1, -structure.anchor().getY(), -structure.zSize + structure.anchor.getZ() + 1);
-            case COUNTERCLOCKWISE_90 -> new Vec3i(-structure.zSize + structure.anchor.getZ() + 1, -structure.anchor().getY(), -structure.xSize + structure.anchor.getX() + 1);
+            case CLOCKWISE_180 -> new Vec3i(-structure.xSize() + structure.anchor().getX() + 1, -structure.anchor().getY(), -structure.zSize() + structure.anchor().getZ() + 1);
+            case COUNTERCLOCKWISE_90 -> new Vec3i(-structure.zSize() + structure.anchor().getZ() + 1, -structure.anchor().getY(), -structure.xSize() + structure.anchor().getX() + 1);
         };
         // @formatter:on
     }

--- a/src/main/java/io/wispforest/lavender/md/features/StructureFeature.java
+++ b/src/main/java/io/wispforest/lavender/md/features/StructureFeature.java
@@ -99,15 +99,15 @@ public class StructureFeature implements MarkdownFeature {
         protected void visitStart(MarkdownCompiler<?> compiler) {
             var structureComponent = StructureFeature.this.bookComponentSource.builtinTemplate(
                     ParentComponent.class,
-                    this.structure.ySize > 1 ? "structure-preview-with-layers" : "structure-preview",
-                    Map.of("structure", this.structure.id.toString(), "angle", String.valueOf(this.angle))
+                    this.structure.ySize() > 1 ? "structure-preview-with-layers" : "structure-preview",
+                    Map.of("structure", this.structure.id().toString(), "angle", String.valueOf(this.angle))
             );
 
             var structurePreview = structureComponent.childById(StructureComponent.class, "structure");
             var layerSlider = structureComponent.childById(SlimSliderComponent.class, "layer-slider");
 
             if (layerSlider != null) {
-                layerSlider.max(0).min(this.structure.ySize).tooltipSupplier(layer -> {
+                layerSlider.max(0).min(this.structure.ySize()).tooltipSupplier(layer -> {
                     return layer > 0
                             ? Text.translatable("text.lavender.structure_component.layer_tooltip", layer.intValue())
                             : Text.translatable("text.lavender.structure_component.all_layers_tooltip");
@@ -115,7 +115,7 @@ public class StructureFeature implements MarkdownFeature {
                     structurePreview.visibleLayer((int) layer - 1);
                 });
 
-                layerSlider.value(StructureOverlayRenderer.getLayerRestriction(this.structure.id) + 1);
+                layerSlider.value(StructureOverlayRenderer.getLayerRestriction(this.structure.id()) + 1);
             }
 
             ((OwoUICompiler) compiler).visitComponent(structureComponent);

--- a/src/main/java/io/wispforest/lavender/mixin/MinecraftClientMixin.java
+++ b/src/main/java/io/wispforest/lavender/mixin/MinecraftClientMixin.java
@@ -1,14 +1,52 @@
 package io.wispforest.lavender.mixin;
 
 import io.wispforest.lavender.client.OffhandBookRenderer;
+import io.wispforest.lavender.client.StructureOverlayRenderer;
+import io.wispforest.lavender.util.RaycastResult;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Comparator;
+
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
+
+    @Shadow
+    @Nullable
+    public ClientPlayerEntity player;
+
+    @Shadow
+    @Nullable
+    public Entity cameraEntity;
+
+    @Shadow
+    @Nullable
+    public HitResult crosshairTarget;
+
+    @Shadow
+    @Nullable
+    public ClientPlayerInteractionManager interactionManager;
+
+    @Shadow
+    @Final
+    private RenderTickCounter renderTickCounter;
 
     @Inject(method = "render", at = @At("HEAD"))
     private void onFrameStart(boolean tick, CallbackInfo ci) {
@@ -18,5 +56,68 @@ public class MinecraftClientMixin {
     @Inject(method = "render", at = @At("TAIL"))
     private void onFrameEnd(boolean tick, CallbackInfo ci) {
         OffhandBookRenderer.endFrame();
+    }
+
+    @Inject(method = "doItemPick", at = @At("HEAD"), cancellable = true)
+    void onItemPick(final CallbackInfo ci) {
+        if (this.player == null || this.cameraEntity == null || this.interactionManager == null)
+            return;
+
+        double blockRange = this.interactionManager.getReachDistance();
+        float tickDelta = this.renderTickCounter.tickDelta;
+        Vec3d rotation = this.player.getRotationVec(tickDelta);
+        Vec3d rayLength = rotation.multiply(blockRange);
+        Vec3d cameraPos = this.player.getCameraPosVec(tickDelta);
+
+        var firstOverlayHit = StructureOverlayRenderer.getActiveOverlays()
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().fetchStructure() != null)
+                .map(entry -> {
+                    BlockPos pos = entry.getKey();
+                    var overlayEntry = entry.getValue();
+                    var template = overlayEntry.fetchStructure();
+                    assert template != null;
+
+                    Vec3d rayStart = cameraPos.subtract(Vec3d.of(pos));
+                    Vec3d rayEnd = rayStart.add(rayLength);
+                    var context = new RaycastContext(rayStart, rayEnd, RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, this.player);
+                    var raycast = template.asBlockRenderView().raycast(context);
+
+                    return new RaycastResult(
+                            raycast,
+                            rayStart,
+                            rayEnd,
+                            template.asBlockRenderView().getBlockState(raycast.getBlockPos()),
+                            template
+                    );
+                })
+                .min(Comparator.comparingDouble((raycast) -> raycast.hitResult().getPos().squaredDistanceTo(raycast.raycastStart())));
+
+        firstOverlayHit.ifPresent((raycast) -> {
+            double hitDistance = raycast.hitResult().getPos().squaredDistanceTo(raycast.raycastStart());
+            double crosshairDistance = this.crosshairTarget != null ? this.crosshairTarget.getPos().squaredDistanceTo(cameraPos) : 0.0;
+
+            if (crosshairDistance < hitDistance) // slightly prefer structure block
+                return;
+
+            ItemStack stack = raycast.block().getBlock().asItem().getDefaultStack();
+
+            PlayerInventory playerInventory = this.player.getInventory();
+
+            int i = playerInventory.getSlotWithStack(stack);
+            if (this.player.getAbilities().creativeMode) {
+                playerInventory.addPickBlock(stack);
+                this.interactionManager.clickCreativeStack(this.player.getStackInHand(Hand.MAIN_HAND), 36 + playerInventory.selectedSlot);
+            } else if (i != -1) {
+                if (PlayerInventory.isValidHotbarIndex(i)) {
+                    playerInventory.selectedSlot = i;
+                } else {
+                    this.interactionManager.pickFromInventory(i);
+                }
+            }
+
+            ci.cancel();
+        });
     }
 }

--- a/src/main/java/io/wispforest/lavender/structure/BlockStatePredicate.java
+++ b/src/main/java/io/wispforest/lavender/structure/BlockStatePredicate.java
@@ -2,6 +2,7 @@ package io.wispforest.lavender.structure;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A predicate used for matching the elements of a structure
@@ -17,13 +18,15 @@ public interface BlockStatePredicate {
      * a full state match
      */
     BlockStatePredicate NULL_PREDICATE = new BlockStatePredicate() {
+        @NotNull
         @Override
-        public BlockState preview() {
-            return Blocks.AIR.getDefaultState();
+        public BlockState[] previewBlockstates() {
+            return new BlockState[]{Blocks.AIR.getDefaultState()};
         }
 
+        @NotNull
         @Override
-        public Result test(BlockState blockState) {
+        public Result test(@NotNull BlockState blockState) {
             return Result.STATE_MATCH;
         }
 
@@ -38,13 +41,15 @@ public interface BlockStatePredicate {
      * match on any air block
      */
     BlockStatePredicate AIR_PREDICATE = new BlockStatePredicate() {
+        @NotNull
         @Override
-        public BlockState preview() {
-            return Blocks.AIR.getDefaultState();
+        public BlockState[] previewBlockstates() {
+            return new BlockState[]{Blocks.AIR.getDefaultState()};
         }
 
+        @NotNull
         @Override
-        public Result test(BlockState blockState) {
+        public Result test(@NotNull BlockState blockState) {
             return blockState.isAir() ? Result.STATE_MATCH : Result.NO_MATCH;
         }
 
@@ -54,13 +59,14 @@ public interface BlockStatePredicate {
         }
     };
 
-    Result test(BlockState state);
+    @NotNull
+    Result test(@NotNull BlockState state);
 
     /**
      * @return {@code true} if this predicate finds a {@linkplain Result#STATE_MATCH state match}
      * on the given state
      */
-    default boolean matches(BlockState state) {
+    default boolean matches(@NotNull BlockState state) {
         return this.test(state) == Result.STATE_MATCH;
     }
 
@@ -69,7 +75,16 @@ public interface BlockStatePredicate {
      * is called every frame the preview is rendered, returning a different sample
      * depending on system time (e.g. to cycle to a block tag) is valid behavior
      */
-    BlockState preview();
+    default BlockState preview() {
+        BlockState[] states = this.previewBlockstates();
+        return states[(int) (System.currentTimeMillis() / 1000 % states.length)];
+    }
+
+    /**
+     * @return An array of all possible preview block states.
+     */
+    @NotNull
+    BlockState[] previewBlockstates();
 
     /**
      * @return Whether this predicate falls into the given matching category, generally

--- a/src/main/java/io/wispforest/lavender/structure/StructureTemplate.java
+++ b/src/main/java/io/wispforest/lavender/structure/StructureTemplate.java
@@ -4,7 +4,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.datafixers.util.Either;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntity;
@@ -13,6 +15,8 @@ import net.minecraft.command.argument.BlockArgumentParser;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.entry.RegistryEntryList;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.Identifier;
@@ -25,21 +29,34 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.ColorResolver;
 import net.minecraft.world.chunk.light.LightingProvider;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.StreamSupport;
 
 public class StructureTemplate {
 
-    private final BlockStatePredicate[][][] predicates;
-    private final EnumMap<BlockStatePredicate.MatchCategory, MutableInt> predicateCountByType;
+    private static final char AIR_BLOCKSTATE_KEY = '_';
+
+    private static final char NULL_BLOCKSTATE_KEY = ' ';
+
+    private static final char ANCHOR_BLOCKSTATE_KEY = '#';
 
     public final int xSize, ySize, zSize;
+
     public final Vec3i anchor;
+
     public final Identifier id;
+
+    private final BlockStatePredicate[][][] predicates;
+
+    private final EnumMap<BlockStatePredicate.MatchCategory, MutableInt> predicateCountByType;
 
     public StructureTemplate(Identifier id, BlockStatePredicate[][][] predicates, int xSize, int ySize, int zSize, @Nullable Vec3i anchor) {
         this.id = id;
@@ -49,8 +66,8 @@ public class StructureTemplate {
         this.zSize = zSize;
 
         this.anchor = anchor != null
-            ? anchor
-            : new Vec3i(this.xSize / 2, 0, this.ySize / 2);
+                ? anchor
+                : new Vec3i(this.xSize / 2, 0, this.ySize / 2);
 
         this.predicateCountByType = new EnumMap<>(BlockStatePredicate.MatchCategory.class);
         for (var type : BlockStatePredicate.MatchCategory.values()) {
@@ -135,7 +152,7 @@ public class StructureTemplate {
 
     /**
      * Shorthand of {@link #countValidStates(World, BlockPos, BlockRotation, BlockStatePredicate.MatchCategory)}
-     * which uses {@link io.wispforest.lavender.structure.BlockStatePredicate.MatchCategory#NON_NULL}
+     * which uses {@link BlockStatePredicate.MatchCategory#NON_NULL}
      */
     public int countValidStates(World world, BlockPos anchor, BlockRotation rotation) {
         return countValidStates(world, anchor, rotation, BlockStatePredicate.MatchCategory.NON_NULL);
@@ -163,51 +180,7 @@ public class StructureTemplate {
     // --- utility ---
 
     public BlockRenderView asBlockRenderView() {
-        var world = MinecraftClient.getInstance().world;
-        return new BlockRenderView() {
-            @Override
-            public float getBrightness(Direction direction, boolean shaded) {
-                return 1f;
-            }
-
-            @Override
-            public LightingProvider getLightingProvider() {
-                return world.getLightingProvider();
-            }
-
-            @Override
-            public int getColor(BlockPos pos, ColorResolver colorResolver) {
-                return colorResolver.getColor(world.getBiome(pos).value(), pos.getX(), pos.getZ());
-            }
-
-            @Nullable
-            @Override
-            public BlockEntity getBlockEntity(BlockPos pos) {
-                return null;
-            }
-
-            @Override
-            public BlockState getBlockState(BlockPos pos) {
-                if (pos.getX() < 0 || pos.getX() >= StructureTemplate.this.xSize || pos.getY() < 0 || pos.getY() >= StructureTemplate.this.ySize || pos.getZ() < 0 || pos.getZ() >= StructureTemplate.this.zSize)
-                    return Blocks.AIR.getDefaultState();
-                return StructureTemplate.this.predicates[pos.getX()][pos.getY()][pos.getZ()].preview();
-            }
-
-            @Override
-            public FluidState getFluidState(BlockPos pos) {
-                return Fluids.EMPTY.getDefaultState();
-            }
-
-            @Override
-            public int getHeight() {
-                return world.getHeight();
-            }
-
-            @Override
-            public int getBottomY() {
-                return world.getBottomY();
-            }
-        };
+        return new StructureTemplateRenderView(Objects.requireNonNull(MinecraftClient.getInstance().world), this);
     }
 
     public static BlockRotation inverse(BlockRotation rotation) {
@@ -221,100 +194,12 @@ public class StructureTemplate {
 
     // --- parsing ---
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @NotNull
     public static StructureTemplate parse(Identifier resourceId, JsonObject json) {
-        var keyObject = JsonHelper.getObject(json, "keys");
-        var keys = new Char2ObjectOpenHashMap<BlockStatePredicate>();
         Vec3i anchor = null;
 
-        for (var entry : keyObject.entrySet()) {
-            char key;
-            if (entry.getKey().length() == 1) {
-                key = entry.getKey().charAt(0);
-                if (key == '#') {
-                    throw new JsonParseException("Key '#' is reserved for 'anchor' declarations");
-                }
-
-            } else if (entry.getKey().equals("anchor")) {
-                key = '#';
-            } else {
-                continue;
-            }
-
-            try {
-                var result = BlockArgumentParser.blockOrTag(Registries.BLOCK.getReadOnlyWrapper(), entry.getValue().getAsString(), false);
-                if (result.left().isPresent()) {
-                    var predicate = result.left().get();
-
-                    keys.put(key, new BlockStatePredicate() {
-                        @Override
-                        public BlockState preview() {
-                            return predicate.blockState();
-                        }
-
-                        @Override
-                        public Result test(BlockState state) {
-                            if (state.getBlock() != predicate.blockState().getBlock()) return Result.NO_MATCH;
-
-                            for (var propAndValue : predicate.properties().entrySet()) {
-                                if (!state.get(propAndValue.getKey()).equals(propAndValue.getValue())) {
-                                    return Result.BLOCK_MATCH;
-                                }
-                            }
-
-                            return Result.STATE_MATCH;
-                        }
-                    });
-                } else {
-                    var predicate = result.right().get();
-
-                    var previewStates = new ArrayList<BlockState>();
-                    predicate.tag().forEach(registryEntry -> {
-                        var block = registryEntry.value();
-                        var state = block.getDefaultState();
-
-                        for (var propAndValue : predicate.vagueProperties().entrySet()) {
-                            Property prop = block.getStateManager().getProperty(propAndValue.getKey());
-                            if (prop == null) return;
-
-                            Optional<Comparable> value = prop.parse(propAndValue.getValue());
-                            if (value.isEmpty()) return;
-
-                            state = state.with(prop, value.get());
-                        }
-
-                        previewStates.add(state);
-                    });
-
-                    keys.put(key, new BlockStatePredicate() {
-                        @Override
-                        public BlockState preview() {
-                            if (previewStates.isEmpty()) return Blocks.AIR.getDefaultState();
-                            return previewStates.get((int) (System.currentTimeMillis() / 1000 % previewStates.size()));
-                        }
-
-                        @Override
-                        public Result test(BlockState state) {
-                            if (!state.isIn(predicate.tag())) return Result.NO_MATCH;
-
-                            for (var propAndValue : predicate.vagueProperties().entrySet()) {
-                                var prop = state.getBlock().getStateManager().getProperty(propAndValue.getKey());
-                                if (prop == null) return Result.BLOCK_MATCH;
-
-                                var expected = prop.parse(propAndValue.getValue());
-                                if (expected.isEmpty()) return Result.BLOCK_MATCH;
-
-                                if (!state.get(prop).equals(expected.get())) return Result.BLOCK_MATCH;
-                            }
-
-                            return Result.STATE_MATCH;
-                        }
-                    });
-                }
-            } catch (CommandSyntaxException e) {
-                throw new JsonParseException("Failed to parse block state predicate", e);
-            }
-        }
+        var keyObject = JsonHelper.getObject(json, "keys");
+        var keys = StructureTemplate.buildStructureKeysMap(keyObject);
 
         var layersArray = JsonHelper.getArray(json, "layers");
         int xSize = 0, ySize = layersArray.size(), zSize = 0;
@@ -361,16 +246,16 @@ public class StructureTemplate {
                     if (keys.containsKey(key)) {
                         predicate = keys.get(key);
 
-                        if (key == '#') {
+                        if (key == ANCHOR_BLOCKSTATE_KEY) {
                             if (anchor != null) {
                                 throw new JsonParseException("Anchor key '#' cannot be used twice within the same structure");
+                            } else {
+                                anchor = new Vec3i(x, y, z);
                             }
-
-                            anchor = new Vec3i(x, y, z);
                         }
-                    } else if (key == ' ') {
+                    } else if (key == NULL_BLOCKSTATE_KEY) {
                         predicate = BlockStatePredicate.NULL_PREDICATE;
-                    } else if (key == '_') {
+                    } else if (key == AIR_BLOCKSTATE_KEY) {
                         predicate = BlockStatePredicate.AIR_PREDICATE;
                     } else {
                         throw new JsonParseException("Unknown key '" + key + "'");
@@ -382,5 +267,236 @@ public class StructureTemplate {
         }
 
         return new StructureTemplate(resourceId, result, xSize, ySize, zSize, anchor);
+    }
+
+    @NotNull
+    private static Char2ObjectOpenHashMap<BlockStatePredicate> buildStructureKeysMap(@NotNull JsonObject keyObject) {
+        var keys = new Char2ObjectOpenHashMap<BlockStatePredicate>();
+        for (var entry : keyObject.entrySet()) {
+            char key;
+            if (entry.getKey().length() == 1) {
+                key = entry.getKey().charAt(0);
+                if (key == ANCHOR_BLOCKSTATE_KEY) {
+                    throw new JsonParseException("Key '#' is reserved for 'anchor' declarations. Rename the key to 'anchor' and use '#' in the structure definition.");
+                } else if (key == AIR_BLOCKSTATE_KEY) {
+                    throw new JsonParseException("Key '_' is a reserved key for marking a block that must be AIR.");
+                } else if (key == NULL_BLOCKSTATE_KEY) {
+                    throw new JsonParseException("Key ' ' is a reserved key for marking a block that can be anything.");
+                }
+            } else if ("anchor".equals(entry.getKey())) {
+                key = ANCHOR_BLOCKSTATE_KEY;
+            } else {
+                throw new JsonParseException("Keys should only be a single character or should be 'anchor'.");
+            }
+
+            if (keys.containsKey(key)) {
+                throw new JsonParseException("Keys can only appear once. Key '" + key + "' appears twice.");
+            }
+
+
+            if (entry.getValue().isJsonArray()) {
+                JsonArray blockStringsArray = entry.getValue().getAsJsonArray();
+                var blockStatePredicates = StreamSupport.stream(blockStringsArray.spliterator(), false)
+                        .map(blockString -> StructureTemplate.parseStringToBlockStatePredicate(blockString.getAsString()))
+                        .toArray(BlockStatePredicate[]::new);
+                keys.put(key, new NestedBlockStatePredicate(blockStatePredicates));
+            } else if (entry.getValue().isJsonPrimitive()) {
+                keys.put(key, StructureTemplate.parseStringToBlockStatePredicate(entry.getValue().getAsString()));
+            } else {
+                throw new JsonParseException("The values for the map of key-to-blocks must either be a string or an array of strings.");
+            }
+        }
+        return keys;
+    }
+
+    @NotNull
+    private static BlockStatePredicate parseStringToBlockStatePredicate(@NotNull String blockOrTag) {
+        try {
+            var result = BlockArgumentParser.blockOrTag(Registries.BLOCK.getReadOnlyWrapper(), blockOrTag, false);
+            return result.map(
+                    blockResult -> new SingleBlockStatePredicate(blockResult.blockState(), blockResult.properties()),
+                    tagResult -> new TagBlockStatePredicate((RegistryEntryList.Named<Block>) tagResult.tag(), tagResult.vagueProperties())
+            );
+        } catch (CommandSyntaxException e) {
+            throw new JsonParseException("Failed to parse block state predicate", e);
+        }
+    }
+
+    public static class NestedBlockStatePredicate implements BlockStatePredicate {
+        @NotNull
+        private final BlockStatePredicate[] predicates;
+
+        @NotNull
+        private final BlockState[] previewStates;
+
+        public NestedBlockStatePredicate(@NotNull BlockStatePredicate[] predicates) {
+            this.predicates = predicates;
+            this.previewStates = Arrays.stream(predicates)
+                    .flatMap((predicate) -> Arrays.stream(predicate.previewBlockstates()))
+                    .toArray(BlockState[]::new);
+        }
+
+        @Override
+        public BlockState[] previewBlockstates() {
+            return this.previewStates;
+        }
+
+        @NotNull
+        @Override
+        public Result test(@NotNull BlockState state) {
+            boolean hasBlockMatch = false;
+            for (var predicate : this.predicates) {
+                var result = predicate.test(state);
+                if (result == Result.STATE_MATCH)
+                    return Result.STATE_MATCH;
+                else if (result == Result.BLOCK_MATCH)
+                    hasBlockMatch = true;
+            }
+
+            return hasBlockMatch ? Result.BLOCK_MATCH : Result.NO_MATCH;
+        }
+    }
+
+    public static class SingleBlockStatePredicate implements BlockStatePredicate {
+        @NotNull
+        private final BlockState state;
+
+        @NotNull
+        private final BlockState[] states;
+
+        @NotNull
+        private final Map<Property<?>, Comparable<?>> properties;
+
+        public SingleBlockStatePredicate(@NotNull BlockState state, @NotNull Map<Property<?>, Comparable<?>> properties) {
+            this.state = state;
+            this.states = new BlockState[]{state};
+            this.properties = properties;
+        }
+
+        @Override
+        public BlockState[] previewBlockstates() {
+            return this.states;
+        }
+
+        @NotNull
+        @Override
+        public Result test(@NotNull BlockState state) {
+            if (state.getBlock() != this.state.getBlock()) return Result.NO_MATCH;
+
+            for (var propAndValue : this.properties.entrySet()) {
+                if (!state.get(propAndValue.getKey()).equals(propAndValue.getValue())) {
+                    return Result.BLOCK_MATCH;
+                }
+            }
+
+            return Result.STATE_MATCH;
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static class TagBlockStatePredicate implements BlockStatePredicate {
+        @NotNull
+        private final TagKey<Block> tag;
+
+        @NotNull
+        private final Map<String, String> vagueProperties;
+
+        @NotNull
+        private final BlockState[] previewStates;
+
+        public TagBlockStatePredicate(@NotNull RegistryEntryList.Named<Block> tagEntries, @NotNull Map<String, String> properties) {
+            this.vagueProperties = properties;
+            this.tag = tagEntries.getTag();
+            this.previewStates = tagEntries.stream().map(entry -> {
+                var block = entry.value();
+                var state = block.getDefaultState();
+
+                for (var propAndValue : this.vagueProperties.entrySet()) {
+                    Property prop = block.getStateManager().getProperty(propAndValue.getKey());
+                    if (prop == null) continue;
+
+                    Optional<Comparable> value = prop.parse(propAndValue.getValue());
+                    if (value.isEmpty()) continue;
+
+                    state = state.with(prop, value.get());
+                }
+
+                return state;
+            }).toArray(BlockState[]::new);
+        }
+
+        @Override
+        public BlockState[] previewBlockstates() {
+            return this.previewStates;
+        }
+
+        @NotNull
+        @Override
+        public Result test(@NotNull BlockState state) {
+            if (!state.isIn(this.tag))
+                return Result.NO_MATCH;
+
+            for (var propAndValue : this.vagueProperties.entrySet()) {
+                var prop = state.getBlock().getStateManager().getProperty(propAndValue.getKey());
+                if (prop == null)
+                    return Result.BLOCK_MATCH;
+
+                var expected = prop.parse(propAndValue.getValue());
+                if (expected.isEmpty())
+                    return Result.BLOCK_MATCH;
+
+                if (!state.get(prop).equals(expected.get()))
+                    return Result.BLOCK_MATCH;
+            }
+
+            return Result.STATE_MATCH;
+        }
+    }
+
+    private record StructureTemplateRenderView(@NotNull World world, @NotNull StructureTemplate template) implements BlockRenderView {
+        @Override
+        public float getBrightness(Direction direction, boolean shaded) {
+            return 1.0f;
+        }
+
+        @Override
+        public LightingProvider getLightingProvider() {
+            return this.world.getLightingProvider();
+        }
+
+        @Override
+        public int getColor(BlockPos pos, ColorResolver colorResolver) {
+            return colorResolver.getColor(this.world.getBiome(pos).value(), pos.getX(), pos.getZ());
+        }
+
+        @Nullable
+        @Override
+        public BlockEntity getBlockEntity(BlockPos pos) {
+            return null;
+        }
+
+        @Override
+        public BlockState getBlockState(BlockPos pos) {
+            if (pos.getX() < 0 || pos.getX() >= this.template.xSize ||
+                pos.getY() < 0 || pos.getY() >= this.template.ySize ||
+                pos.getZ() < 0 || pos.getZ() >= this.template.zSize)
+                return Blocks.AIR.getDefaultState();
+            return this.template.predicates[pos.getX()][pos.getY()][pos.getZ()].preview();
+        }
+
+        @Override
+        public FluidState getFluidState(BlockPos pos) {
+            return Fluids.EMPTY.getDefaultState();
+        }
+
+        @Override
+        public int getHeight() {
+            return this.world.getHeight();
+        }
+
+        @Override
+        public int getBottomY() {
+            return this.world.getBottomY();
+        }
     }
 }

--- a/src/main/java/io/wispforest/lavender/util/RaycastResult.java
+++ b/src/main/java/io/wispforest/lavender/util/RaycastResult.java
@@ -1,0 +1,15 @@
+package io.wispforest.lavender.util;
+
+import io.wispforest.lavender.structure.StructureTemplate;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.Vec3d;
+
+public record RaycastResult(
+        BlockHitResult hitResult,
+        Vec3d raycastStart,
+        Vec3d raycastEnd,
+        BlockState block,
+        StructureTemplate template
+) {
+}


### PR DESCRIPTION
Changed several things to do with `StructureTemplate`s:

- Add support for structure block keys with a list of items (Fixes #7)
- Add iterator to structure template
- Add getters for structure template fields (I personally had a usecase where I wanted to access some of the fields)
- Support pickblocking the block in the structure preview. (if a structure preview is active and you middle-click on a block, it will place it into your inventory if in creative, or take it from the items you have in your inventory if in survival)
- Persist structure previews across world reloads (exiting then re-opening world)