### PR TITLE
Add rendering for fluids to in-world structure previews

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation "io.wispforest:owo-lib:${project.owo_version}"
+    annotationProcessor modImplementation("io.wispforest:owo-lib:${project.owo_version}")
     include "io.wispforest:owo-sentinel:${project.owo_version}"
 
 //    modLocalRuntime "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"

--- a/src/main/java/io/wispforest/lavender/Lavender.java
+++ b/src/main/java/io/wispforest/lavender/Lavender.java
@@ -21,6 +21,7 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.PersistentState;
 import org.slf4j.Logger;
+import io.wispforest.lavender.LavenderConfig;
 
 import java.util.UUID;
 
@@ -31,6 +32,8 @@ public class Lavender implements ModInitializer {
     public static final SoundEvent ITEM_BOOK_OPEN = SoundEvent.of(id("item.book.open"));
 
     public static final Identifier WORLD_ID_CHANNEL = Lavender.id("world_id_channel");
+
+    public static final LavenderConfig CONFIG = LavenderConfig.createAndLoad();
 
     @Override
     public void onInitialize() {

--- a/src/main/java/io/wispforest/lavender/LavenderConfigModel.java
+++ b/src/main/java/io/wispforest/lavender/LavenderConfigModel.java
@@ -1,0 +1,12 @@
+package io.wispforest.lavender;
+
+import io.wispforest.owo.config.annotation.Config;
+import io.wispforest.owo.config.annotation.Modmenu;
+import io.wispforest.owo.config.annotation.RangeConstraint;
+
+@Modmenu(modId = Lavender.MOD_ID)
+@Config(name = "lavender", wrapperName = "LavenderConfig")
+public class LavenderConfigModel {
+    @RangeConstraint(min = 0.0, max = 1.0)
+    public float structurePreviewAlpha = 0.5f;
+}

--- a/src/main/resources/assets/lavender/lang/en_us.json
+++ b/src/main/resources/assets/lavender/lang/en_us.json
@@ -68,5 +68,7 @@
   ],
 
   "text.lavender.book.bookmark.add": "Add Bookmark",
-  "text.lavender.book.bookmark.remove_hint": {"text": "Shift-click to remove", "color": "dark_gray"}
+  "text.lavender.book.bookmark.remove_hint": {"text": "Shift-click to remove", "color": "dark_gray"},
+
+  "text.config.lavender.option.structurePreviewAlpha": "Structure Preview Alpha"
 }

--- a/src/testmod/resources/assets/lavender-flower/lavender/structures/conduit.json
+++ b/src/testmod/resources/assets/lavender-flower/lavender/structures/conduit.json
@@ -1,0 +1,44 @@
+{
+    "keys":   {
+        "p":      "minecraft:prismarine",
+        ",":      "minecraft:water",
+        "anchor": "minecraft:conduit"
+    },
+    "layers": [
+        [
+            "  p  ",
+            "  p  ",
+            "ppppp",
+            "  p  ",
+            "  p  "
+        ],
+        [
+            "  p  ",
+            " ,,, ",
+            "p,,,p",
+            " ,,, ",
+            "  p  "
+        ],
+        [
+            "ppppp",
+            "p,,,p",
+            "p,#,p",
+            "p,,,p",
+            "ppppp"
+        ],
+        [
+            "  p  ",
+            " ,,, ",
+            "p,,,p",
+            " ,,, ",
+            "  p  "
+        ],
+        [
+            "  p  ",
+            "  p  ",
+            "ppppp",
+            "  p  ",
+            "  p  "
+        ]
+    ]
+}


### PR DESCRIPTION
This PR adds rendering for fluids (water, lava, as well as modded fluids\*) to the in-world structure preview.

Other minor (associated) changes:
- Add a new structure to the testmod that contains water. This is only for testing purposes.
- Add config to lavender to allow changing opacity of preview I found it was a tad difficult to see the water, as it's now doubly transparent (water is transparent + the preview is transparent), so instead I made it adjustable
  - Config is done using owo-config, as it's already included
  - Added english translation for config option. (I don't know german, so can't do that)


\*Has not been tested