### PR TITLE
Implement `additional_search_terms` field in entry metadata

### DIFF
--- a/src/main/java/io/wispforest/lavender/book/BookContentLoader.java
+++ b/src/main/java/io/wispforest/lavender/book/BookContentLoader.java
@@ -121,7 +121,19 @@ public class BookContentLoader implements SynchronousResourceReloader, Identifia
                     requiredAdvancements.add(advancementId);
                 }
 
-                var entry = new Entry(identifier, entryCategories, title, icon, secret, ordinal, requiredAdvancements.build(), associatedItems.build(), markdown.content);
+                var additionalSearchTerms = new ImmutableSet.Builder<String>();
+                for (var termElement : JsonHelper.getArray(markdown.meta, "additional_search_terms", new JsonArray())) {
+                    if (!termElement.isJsonPrimitive()) continue;
+
+                    var term = termElement.getAsString();
+                    // Lowercase the term in advance to save a little time when searching.
+                    additionalSearchTerms.add(term.toLowerCase(Locale.ROOT));
+                }
+
+                var entry = new Entry(
+                        identifier, entryCategories, title, icon, secret, ordinal, requiredAdvancements.build(),
+                        associatedItems.build(), additionalSearchTerms.build(), markdown.content
+                );
                 if (entry.id().getPath().equals("landing_page")) {
                     book.setLandingPage(entry);
                 } else {

--- a/src/main/java/io/wispforest/lavender/book/BookContentLoader.java
+++ b/src/main/java/io/wispforest/lavender/book/BookContentLoader.java
@@ -131,8 +131,16 @@ public class BookContentLoader implements SynchronousResourceReloader, Identifia
                 }
 
                 var entry = new Entry(
-                        identifier, entryCategories, title, icon, secret, ordinal, requiredAdvancements.build(),
-                        associatedItems.build(), additionalSearchTerms.build(), markdown.content
+                        identifier,
+                        entryCategories,
+                        title,
+                        icon,
+                        secret,
+                        ordinal,
+                        requiredAdvancements.build(),
+                        associatedItems.build(),
+                        additionalSearchTerms.build(),
+                        markdown.content
                 );
                 if (entry.id().getPath().equals("landing_page")) {
                     book.setLandingPage(entry);

--- a/src/main/java/io/wispforest/lavender/book/Entry.java
+++ b/src/main/java/io/wispforest/lavender/book/Entry.java
@@ -20,6 +20,7 @@ public record Entry(
         int ordinal,
         ImmutableSet<Identifier> requiredAdvancements,
         ImmutableSet<ItemStack> associatedItems,
+        ImmutableSet<String> additionalSearchTerms,
         String content
 ) implements Book.BookmarkableElement {
 

--- a/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
+++ b/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
@@ -608,9 +608,34 @@ public class LavenderBookScreen extends BaseUIModelScreen<FlowLayout> implements
                             if (!entryVisible) return;
 
                             var entryTitle = entry.title().toLowerCase(Locale.ROOT);
+
+                            var entryMatches = true;
                             for (var term : filter) {
-                                if (!entryTitle.contains(term)) return;
+                                if (!entryTitle.contains(term)) {
+                                    entryMatches = false;
+                                    break;
+                                }
                             }
+
+                            // If the title doesn't match, check each additional term in turn.
+                            if (!entryMatches) {
+                                for (var extraTerm : entry.additionalSearchTerms()) {
+                                    var termMatches = true;
+                                    for (var term : filter) {
+                                        if (!extraTerm.contains(term)) {
+                                            termMatches = false;
+                                            break;
+                                        }
+                                    }
+
+                                    if (termMatches) {
+                                        entryMatches = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (!entryMatches) return;
                         }
 
                         FlowLayout indexItem;

--- a/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
+++ b/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
@@ -609,32 +609,8 @@ public class LavenderBookScreen extends BaseUIModelScreen<FlowLayout> implements
 
                             var entryTitle = entry.title().toLowerCase(Locale.ROOT);
 
-                            var entryMatches = true;
-                            for (var term : filter) {
-                                if (!entryTitle.contains(term)) {
-                                    entryMatches = false;
-                                    break;
-                                }
-                            }
-
-                            // If the title doesn't match, check each additional term in turn.
-                            if (!entryMatches) {
-                                for (var extraTerm : entry.additionalSearchTerms()) {
-                                    var termMatches = true;
-                                    for (var term : filter) {
-                                        if (!extraTerm.contains(term)) {
-                                            termMatches = false;
-                                            break;
-                                        }
-                                    }
-
-                                    if (termMatches) {
-                                        entryMatches = true;
-                                        break;
-                                    }
-                                }
-                            }
-
+                            var entryMatches = Arrays.stream(filter).allMatch(entryTitle::contains)
+                                    || entry.additionalSearchTerms().stream().anyMatch(term -> Arrays.stream(filter).allMatch(term::contains));
                             if (!entryMatches) return;
                         }
 

--- a/src/testmod/resources/assets/lavender-flower/lavender/entries/the_book/profounder_pagee.md
+++ b/src/testmod/resources/assets/lavender-flower/lavender/entries/the_book/profounder_pagee.md
@@ -6,6 +6,11 @@
   "associated_items": [
     "minecraft:enchanted_book{StoredEnchantments:[{id:'minecraft:unbreaking', lvl:3s}]}",
     "#minecraft:candles"
+  ],
+  "additional_search_terms": [
+    "incredible",
+    "im 14 and this is deep",
+    "I NEED PSYCHIATRIC HELP"
   ]
 }
 ```


### PR DESCRIPTION
As discussed in Discord.

I've made sure to treat the title and each additional search term as separate "results". This means either the title or any single additional term must include *all* words of the search text for the entry to pass.