### PR TITLE
Adding ability to reverse the scroll direction

### DIFF
--- a/src/main/java/io/wispforest/lavender/LavenderCommands.java
+++ b/src/main/java/io/wispforest/lavender/LavenderCommands.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import io.wispforest.lavender.book.Book;
 import io.wispforest.lavender.book.BookLoader;
 import io.wispforest.lavender.book.LavenderBookItem;
+import io.wispforest.lavender.book.LavenderClientStorage;
 import io.wispforest.lavender.client.StructureOverlayRenderer;
 import io.wispforest.lavender.structure.LavenderStructures;
 import net.fabricmc.api.EnvType;
@@ -110,6 +111,19 @@ public class LavenderCommands {
                                 StructureOverlayRenderer.addPendingOverlay(structureId);
                                 return 0;
                             }))));
+
+            dispatcher.register(literal("book-scroll-reversed")
+                    .executes(context -> {
+                        var reversed = LavenderClientStorage.isBookScrollReversed();
+                        context.getSource().sendFeedback(Text.literal("Guidebook scroll direction is currently " + (reversed ? "reversed" : "normal")));
+                        return 0;
+                    })
+                    .then(argument("reversed", BoolArgumentType.bool()).executes(context -> {
+                        var reversed = BoolArgumentType.getBool(context, "reversed");
+                        LavenderClientStorage.setBookScrollReversed(reversed);
+                        context.getSource().sendFeedback(Text.literal("Guidebook scroll direction set to " + (reversed ? "reversed" : "normal")));
+                        return 0;
+                    })));
         }
     }
 

--- a/src/main/java/io/wispforest/lavender/book/LavenderClientStorage.java
+++ b/src/main/java/io/wispforest/lavender/book/LavenderClientStorage.java
@@ -26,6 +26,8 @@ public class LavenderClientStorage {
     private static final TypeToken<Map<UUID, Map<Identifier, Set<Identifier>>>> VIEWED_ENTRIES_TYPE = new TypeToken<>() {};
     private static Map<UUID, Map<Identifier, Set<Identifier>>> viewedEntries;
 
+    private static Boolean bookScrollReversed;
+
     private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Identifier.class, new Identifier.Serializer()).setPrettyPrinting().create();
 
     static {
@@ -35,14 +37,17 @@ public class LavenderClientStorage {
             bookmarks = GSON.fromJson(data.get("bookmarks"), BOOKMARKS_TYPE);
             openedBooks = GSON.fromJson(data.get("opened_books"), OPENED_BOOKS_TYPE);
             viewedEntries = GSON.fromJson(data.get("viewed_entries"), VIEWED_ENTRIES_TYPE);
+            bookScrollReversed = GSON.fromJson(data.get("book_scroll_reversed"), Boolean.class);
 
             if (bookmarks == null) bookmarks = new HashMap<>();
             if (openedBooks == null) openedBooks = new HashMap<>();
             if (viewedEntries == null) viewedEntries = new HashMap<>();
+            if (bookScrollReversed == null) bookScrollReversed = false;
         } catch (Exception e) {
             bookmarks = new HashMap<>();
             openedBooks = new HashMap<>();
             viewedEntries = new HashMap<>();
+            bookScrollReversed = false;
             save();
         }
     }
@@ -94,6 +99,15 @@ public class LavenderClientStorage {
         save();
     }
 
+    public static boolean isBookScrollReversed() {
+        return bookScrollReversed;
+    }
+
+    public static void setBookScrollReversed(boolean reversed) {
+        bookScrollReversed = reversed;
+        save();
+    }
+
     private static Set<Identifier> getOpenedBooksSet() {
         return openedBooks.computeIfAbsent(LavenderClient.currentWorldId(), $ -> new HashSet<>());
     }
@@ -104,6 +118,7 @@ public class LavenderClientStorage {
             data.add("bookmarks", GSON.toJsonTree(bookmarks, BOOKMARKS_TYPE.getType()));
             data.add("opened_books", GSON.toJsonTree(openedBooks, OPENED_BOOKS_TYPE.getType()));
             data.add("viewed_entries", GSON.toJsonTree(viewedEntries, VIEWED_ENTRIES_TYPE.getType()));
+            data.addProperty("book_scroll_reversed", bookScrollReversed);
 
             Files.writeString(storageFile(), GSON.toJson(data));
         } catch (IOException e) {

--- a/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
+++ b/src/main/java/io/wispforest/lavender/client/LavenderBookScreen.java
@@ -304,6 +304,10 @@ public class LavenderBookScreen extends BaseUIModelScreen<FlowLayout> implements
     }
 
     private void turnPage(boolean left) {
+        if (LavenderClientStorage.isBookScrollReversed()) {
+            left = !left;
+        }
+
         var frame = this.currentNavFrame();
 
         int previousPage = frame.selectedPage;


### PR DESCRIPTION
Issue #30 asked for the ability to reverse the scroll direction which seems fairly simple to add, and this adds the ability to do so. It also adds a command `/book-scroll-reversed <reversed>` to set it to be reversed, and loads/saves that state in `lavender_client_storage.json`. 